### PR TITLE
566 fix icon moves down and out of sight

### DIFF
--- a/src/app/packages/menu-items/tools/overlays-display-mode/overlays-display-mode.component.less
+++ b/src/app/packages/menu-items/tools/overlays-display-mode/overlays-display-mode.component.less
@@ -17,7 +17,7 @@
 			opacity: 1;
 		}
 		visibility: visible;
-		width: 114px;
+		width: 115px;
 		height: 33px;
 	}
 


### PR DESCRIPTION
resolve #566 for some reason in carmels computer the space was to small for the icon, adding 1 pixel to container solved it