### PR TITLE
fix(enum-filter): don't crash when overlay does not exist

### DIFF
--- a/src/app/packages/menu-items/filters/models/metadata/enum-filter-metadata.ts
+++ b/src/app/packages/menu-items/filters/models/metadata/enum-filter-metadata.ts
@@ -39,6 +39,9 @@ export class EnumFilterMetadata implements FilterMetadata {
 	}
 
 	filterFunc(overlay: any, filteringParams: { key: string, metadata: EnumFilterMetadata }): boolean {
+		if (!overlay) {
+			return false;
+		}
 		const selectedFields: string[] = [];
 		filteringParams.metadata.enumsFields.forEach((value: { count: number, isChecked: boolean }, key: string) => {
 			if (value.isChecked) {


### PR DESCRIPTION
resolve #680 