### PR TITLE
fix(open-layers-map): make sync accurate

### DIFF
--- a/src/app/packages/open-layers-map/map/open-layers-map.ts
+++ b/src/app/packages/open-layers-map/map/open-layers-map.ts
@@ -345,9 +345,6 @@ export class OpenLayersMap implements IMap {
 		view.setCenter(olCenter);
 		view.setRotation(position.rotation);
 		view.setZoom(position.zoom);
-		if (position.boundingBox) {
-			this.setBoundingBox(position.boundingBox);
-		}
 	}
 
 	public getPosition(): MapPosition {


### PR DESCRIPTION
@asafMasa Setting the extent here creates a weird bug.
Repro:
- Show 4 maps
- Press sync on the first
- Press sync on the second (stuff will move)

center + orientation + zoom seems sufficient enough, or, and a bounding box can actually be a mistake imo between different map aspect ratios.

If you have an objection speak now or forever hold your piece