### PR TITLE
fix (map-loader) Overlay progress bar is hidden when imagery window is active

### DIFF
--- a/src/app/packages/core/less/z-index-globals.less
+++ b/src/app/packages/core/less/z-index-globals.less
@@ -3,7 +3,7 @@
 @z-index-go-to-close: 1;
 @z-index-map-rotation: 2;
 @z-index-go-to-component: 2;
-@z-index-map-loader: 2;
+@z-index-map-loader: 3;
 @z-index-overlays-display-mode-component: 2;
 @z-index-tooltip-after: 2;
 @z-index-case-menu: 2;


### PR DESCRIPTION
this should fix issue #1152 