### PR TITLE
Integrate with the storage service

### DIFF
--- a/src/app/app/app-effects/effects/layers.app.effects.spec.ts
+++ b/src/app/app/app-effects/effects/layers.app.effects.spec.ts
@@ -72,7 +72,7 @@ describe('LayersAppEffects', () => {
 			const expectedResults = cold('--(abc)--', {
 				a: new SetAnnotationsLayer(<any>'geoJSON'),
 				b: new ToggleDisplayAnnotationsLayer(true),
-				c: new BeginLayerTreeLoadAction({ caseId: 'id' })
+				c: new BeginLayerTreeLoadAction()
 			});
 			expect(layersAppEffects.selectCase$).toBeObservable(expectedResults);
 		});

--- a/src/app/app/app-effects/effects/layers.app.effects.ts
+++ b/src/app/app/app-effects/effects/layers.app.effects.ts
@@ -34,7 +34,7 @@ export class LayersAppEffects {
 		.mergeMap((action: SelectCaseAction) => [
 			new SetAnnotationsLayer(action.payload.state.layers.annotationsLayer),
 			new ToggleDisplayAnnotationsLayer(action.payload.state.layers.displayAnnotationsLayer),
-			new BeginLayerTreeLoadAction({ caseId: action.payload.id }),
+			new BeginLayerTreeLoadAction()
 		]).share();
 
 	/**

--- a/src/app/packages/core/models/case.model.ts
+++ b/src/app/packages/core/models/case.model.ts
@@ -4,11 +4,12 @@ import { FeatureCollection } from 'geojson';
 import { IVisualizerEntity } from '@ansyn/imagery/model/imap-visualizer';
 
 export interface Case {
-	readonly id?: string;
+	id?: string;
 	name?: string;
 	owner?: string;
 	lastModified?: Date;
 	state?: CaseState;
+	creationTime?: Date;
 }
 
 export interface IContextEntity extends IVisualizerEntity {

--- a/src/app/packages/menu-items/cases/effects/cases.effects.ts
+++ b/src/app/packages/menu-items/cases/effects/cases.effects.ts
@@ -43,8 +43,9 @@ export class CasesEffects {
 	@Effect()
 	loadCases$: Observable<LoadCasesSuccessAction> = this.actions$
 		.ofType(CasesActionTypes.LOAD_CASES)
-		.switchMap(() => {
-			return this.casesService.loadCases()
+		.withLatestFrom(this.store.select(casesStateSelector))
+		.switchMap(([action, casesState]: [LoadCasesAction, ICasesState]) => {
+			return this.casesService.loadCases(casesState.cases.length)
 				.map(newCases => {
 					return new LoadCasesSuccessAction(newCases);
 				});

--- a/src/app/packages/menu-items/cases/effects/cases.effects.ts
+++ b/src/app/packages/menu-items/cases/effects/cases.effects.ts
@@ -43,11 +43,8 @@ export class CasesEffects {
 	@Effect()
 	loadCases$: Observable<LoadCasesSuccessAction> = this.actions$
 		.ofType(CasesActionTypes.LOAD_CASES)
-		.withLatestFrom(this.store.select(casesStateSelector))
-		.switchMap(([action, state]: [LoadCasesAction, ICasesState]) => {
-			let lastCase: Case = state.cases[state.cases.length - 1];
-			let lastId = lastCase ? lastCase.id : '-1';
-			return this.casesService.loadCases(lastId)
+		.switchMap(() => {
+			return this.casesService.loadCases()
 				.map(newCases => {
 					return new LoadCasesSuccessAction(newCases);
 				});

--- a/src/app/packages/menu-items/cases/effects/cases.effects.ts
+++ b/src/app/packages/menu-items/cases/effects/cases.effects.ts
@@ -101,7 +101,7 @@ export class CasesEffects {
 		.map(toPayload)
 		.switchMap((deletedCaseId) => {
 			return this.casesService.removeCase(deletedCaseId)
-				.map((deletedCase: Case) => new DeleteCaseBackendSuccessAction(deletedCase));
+				.map(() => new DeleteCaseBackendSuccessAction(deletedCaseId));
 		}).share();
 
 	/**

--- a/src/app/packages/menu-items/cases/reducers/cases.reducer.spec.ts
+++ b/src/app/packages/menu-items/cases/reducers/cases.reducer.spec.ts
@@ -14,6 +14,7 @@ import { CasesReducer, ICasesState, initialCasesState } from './cases.reducer';
 import { CasesService } from '../services/cases.service';
 import { cloneDeep } from 'lodash';
 import * as config from '../../../../../assets/config/app.config.json';
+import { DeleteCaseBackendSuccessAction } from '@ansyn/menu-items';
 
 
 describe('CasesReducer', () => {
@@ -106,15 +107,15 @@ describe('CasesReducer', () => {
 		expect(result.cases.length).toEqual(6);
 	});
 
-	it('DELETE_CASE action should delete case from state.cases by modalCaseId', () => {
+	it('DELETE_CASE_BACKEND_SUCCESS action should delete case from state.cases', () => {
 		let state: ICasesState = initialCasesState;
 		state.cases = [
 			{ id: 'id1', name: 'name1' },
 			{ id: 'id2', name: 'name2' },
 			{ id: 'id3', name: 'name3' }
 		];
-		state.modalCaseId = 'id1';
-		let action: DeleteCaseAction = new DeleteCaseAction();
+
+		let action: DeleteCaseAction = new DeleteCaseBackendSuccessAction('id1');
 		let result: ICasesState = CasesReducer(state, action);
 		expect(result.cases.length).toEqual(2);
 	});

--- a/src/app/packages/menu-items/cases/reducers/cases.reducer.ts
+++ b/src/app/packages/menu-items/cases/reducers/cases.reducer.ts
@@ -89,7 +89,13 @@ export function CasesReducer(state: ICasesState = initialCasesState, action: Cas
 			return { ...state, cases: casesLoaded };
 
 		case CasesActionTypes.DELETE_CASE:
-			const caseToRemoveIndex: number = state.cases.findIndex((caseValue: Case) => caseValue.id === state.modalCaseId);
+			return state;
+
+		case CasesActionTypes.DELETE_CASE_BACKEND:
+			return Object.assign({}, state, { updatingBackend: true });
+
+		case CasesActionTypes.DELETE_CASE_BACKEND_SUCCESS:
+			const caseToRemoveIndex: number = state.cases.findIndex((caseValue: Case) => caseValue.id === action.payload);
 			if (caseToRemoveIndex === -1) {
 				return state;
 			}
@@ -97,13 +103,8 @@ export function CasesReducer(state: ICasesState = initialCasesState, action: Cas
 				...state.cases.slice(0, caseToRemoveIndex),
 				...state.cases.slice(caseToRemoveIndex + 1, state.cases.length)
 			];
-			return Object.assign({}, state, { cases });
 
-		case CasesActionTypes.DELETE_CASE_BACKEND:
-			return Object.assign({}, state, { updatingBackend: true });
-
-		case CasesActionTypes.DELETE_CASE_BACKEND_SUCCESS:
-			return Object.assign({}, state, { updatingBackend: false });
+			return Object.assign({}, state, { updatingBackend: false, cases });
 
 		case CasesActionTypes.SELECT_CASE:
 			const selectedCase = deepMerge(CasesService.defaultCase, action.payload);

--- a/src/app/packages/menu-items/cases/services/cases.service.spec.ts
+++ b/src/app/packages/menu-items/cases/services/cases.service.spec.ts
@@ -7,11 +7,6 @@ import { Observable } from 'rxjs/Observable';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { ErrorHandlerService } from '@ansyn/core';
 import 'rxjs/add/observable/of';
-import { Store, StoreModule } from '@ngrx/store';
-import {
-	casesFeatureKey, CasesReducer, casesStateSelector,
-	ICasesState
-} from '@ansyn/menu-items/cases/reducers/cases.reducer';
 import { UUID } from 'angular2-uuid';
 
 export const MockCasesConfig = {
@@ -36,7 +31,7 @@ describe('CasesService', () => {
 
 	beforeEach(() => {
 		TestBed.configureTestingModule({
-			imports: [HttpClientModule, StoreModule.forRoot({ [casesFeatureKey]: CasesReducer })],
+			imports: [HttpClientModule],
 			providers: [CasesService, UrlSerializer, MockCasesConfig, {
 				provide: ErrorHandlerService,
 				useValue: { httpErrorHandle: () => Observable.throw(null) }

--- a/src/app/packages/menu-items/cases/services/cases.service.ts
+++ b/src/app/packages/menu-items/cases/services/cases.service.ts
@@ -47,7 +47,7 @@ export class CasesService {
 		this.casesOffset$.subscribe(casesOffset => this.casesOffset = casesOffset);
 	}
 
-	loadCases(lastId: string = '-1'): Observable<any> {
+	loadCases(): Observable<any> {
 		const url = `${this.baseUrl}/cases/?from=${this.casesOffset}&limit=${this.paginationLimit}`;
 		return this.http.get(url).catch(err => {
 			return this.errorHandlerService.httpErrorHandle(err);

--- a/src/app/packages/menu-items/cases/services/cases.service.ts
+++ b/src/app/packages/menu-items/cases/services/cases.service.ts
@@ -10,8 +10,6 @@ import { QueryParamsHelper } from './helpers/cases.service.query-params-helper';
 import { UrlSerializer } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
 import { ErrorHandlerService } from '@ansyn/core';
-import { casesStateSelector, ICasesState } from "../reducers/cases.reducer";
-import { Store } from "@ngrx/store";
 import { UUID } from "angular2-uuid";
 
 export const casesConfig: InjectionToken<ICasesConfig> = new InjectionToken('cases-config');
@@ -32,23 +30,16 @@ export class CasesService {
 		time: undefined
 	};
 
-	casesOffset$: Observable<number> = this.store.select(casesStateSelector)
-		.map(({ cases }: ICasesState) => cases.length );
-
-	casesOffset: number;
-
 	constructor(protected http: HttpClient, @Inject(casesConfig) public config: ICasesConfig, public urlSerializer: UrlSerializer,
-				public store: Store<ICasesState>,
 				@Inject(ErrorHandlerService) public errorHandlerService: ErrorHandlerService) {
 		this.baseUrl = this.config.baseUrl;
 		this.paginationLimit = this.config.paginationLimit;
 		this.queryParamsKeys = this.config.casesQueryParamsKeys;
 		CasesService.defaultCase = config.defaultCase;
-		this.casesOffset$.subscribe(casesOffset => this.casesOffset = casesOffset);
 	}
 
-	loadCases(): Observable<any> {
-		const url = `${this.baseUrl}/cases/?from=${this.casesOffset}&limit=${this.paginationLimit}`;
+	loadCases(casesOffset: number = 0): Observable<any> {
+		const url = `${this.baseUrl}/cases/?from=${casesOffset}&limit=${this.paginationLimit}`;
 		return this.http.get(url).catch(err => {
 			return this.errorHandlerService.httpErrorHandle(err);
 		});

--- a/src/app/packages/menu-items/cases/services/cases.service.ts
+++ b/src/app/packages/menu-items/cases/services/cases.service.ts
@@ -95,7 +95,7 @@ export class CasesService {
 	}
 
 	loadCase(selectedCaseId: string): Observable<any> {
-		const url = `${this.baseUrl}/contexts/${selectedCaseId}`;
+		const url = `${this.baseUrl}/cases/${selectedCaseId}`;
 		return this.http.get(url).catch(err => {
 			return this.errorHandlerService.httpErrorHandle(err);
 		});

--- a/src/app/packages/menu-items/cases/services/helpers/cases.service.query-params-helper.spec.ts
+++ b/src/app/packages/menu-items/cases/services/helpers/cases.service.query-params-helper.spec.ts
@@ -9,7 +9,6 @@ import { MockCasesConfig } from '../cases.service.spec';
 import { HttpClientModule } from '@angular/common/http';
 import { ErrorHandlerService } from '@ansyn/core';
 import { Observable } from 'rxjs/Observable';
-import { casesFeatureKey, CasesReducer } from '@ansyn/menu-items/cases/reducers/cases.reducer';
 import { StoreModule } from '@ngrx/store';
 
 describe('CasesService', () => {
@@ -17,7 +16,7 @@ describe('CasesService', () => {
 	let urlSerializer: UrlSerializer;
 	beforeEach(() => {
 		TestBed.configureTestingModule({
-			imports: [HttpClientModule, StoreModule.forRoot({ [casesFeatureKey]: CasesReducer })],
+			imports: [HttpClientModule],
 			providers: [
 				CasesService,
 				{

--- a/src/app/packages/menu-items/cases/services/helpers/cases.service.query-params-helper.spec.ts
+++ b/src/app/packages/menu-items/cases/services/helpers/cases.service.query-params-helper.spec.ts
@@ -9,13 +9,15 @@ import { MockCasesConfig } from '../cases.service.spec';
 import { HttpClientModule } from '@angular/common/http';
 import { ErrorHandlerService } from '@ansyn/core';
 import { Observable } from 'rxjs/Observable';
+import { casesFeatureKey, CasesReducer } from '@ansyn/menu-items/cases/reducers/cases.reducer';
+import { StoreModule } from '@ngrx/store';
 
 describe('CasesService', () => {
 	let casesService: CasesService;
 	let urlSerializer: UrlSerializer;
 	beforeEach(() => {
 		TestBed.configureTestingModule({
-			imports: [HttpClientModule],
+			imports: [HttpClientModule, StoreModule.forRoot({ [casesFeatureKey]: CasesReducer })],
 			providers: [
 				CasesService,
 				{

--- a/src/app/packages/menu-items/cases/services/helpers/cases.service.query-params-helper.spec.ts
+++ b/src/app/packages/menu-items/cases/services/helpers/cases.service.query-params-helper.spec.ts
@@ -9,7 +9,6 @@ import { MockCasesConfig } from '../cases.service.spec';
 import { HttpClientModule } from '@angular/common/http';
 import { ErrorHandlerService } from '@ansyn/core';
 import { Observable } from 'rxjs/Observable';
-import { StoreModule } from '@ngrx/store';
 
 describe('CasesService', () => {
 	let casesService: CasesService;

--- a/src/app/packages/menu-items/layers-manager/actions/layers.actions.ts
+++ b/src/app/packages/menu-items/layers-manager/actions/layers.actions.ts
@@ -41,9 +41,6 @@ export class SetAnnotationsLayer implements Action {
 
 export class BeginLayerTreeLoadAction implements Action {
 	type = LayersActionTypes.BEGIN_LAYER_TREE_LOAD;
-
-	constructor(public payload: { caseId: string }) {
-	}
 }
 
 export class LayerTreeLoadedAction implements Action {

--- a/src/app/packages/menu-items/layers-manager/effects/layers.effects.spec.ts
+++ b/src/app/packages/menu-items/layers-manager/effects/layers.effects.spec.ts
@@ -94,7 +94,7 @@ describe('LayersEffects', () => {
 
 		let loadedTreeBundle = { layers: layers, selectedLayers: selectedLayers };
 		spyOn(dataLayersService, 'getAllLayersInATree').and.callFake(() => Observable.of(loadedTreeBundle));
-		actions = hot('--a--', { a: new BeginLayerTreeLoadAction({ caseId: 'blabla' }) });
+		actions = hot('--a--', { a: new BeginLayerTreeLoadAction() });
 		const expectedResults = cold('--(ab)--', {
 			a: new LayerTreeLoadedAction(<any>loadedTreeBundle),
 			b: new SelectLayerAction(<any>staticLeaf)

--- a/src/app/packages/menu-items/layers-manager/effects/layers.effects.ts
+++ b/src/app/packages/menu-items/layers-manager/effects/layers.effects.ts
@@ -34,8 +34,8 @@ export class LayersEffects {
 	@Effect()
 	beginLayerTreeLoad$: Observable<LayersActions> = this.actions$
 		.ofType(LayersActionTypes.BEGIN_LAYER_TREE_LOAD)
-		.switchMap((action: BeginLayerTreeLoadAction) => {
-			return this.dataLayersService.getAllLayersInATree(action.payload.caseId);
+		.switchMap(() => {
+			return this.dataLayersService.getAllLayersInATree();
 		})
 		.withLatestFrom(this.store.select(layersStateSelector))
 		.mergeMap(([layersBundle, store]: [LayerRootsBundle, ILayerState]) => {

--- a/src/app/packages/menu-items/layers-manager/services/data-layers.service.spec.ts
+++ b/src/app/packages/menu-items/layers-manager/services/data-layers.service.spec.ts
@@ -43,7 +43,7 @@ describe('DataLayersService', () => {
 		expect(service).toBeTruthy();
 	}));
 
-	it('getAllLayersInATree should send the case id in a get request', () => {
+	it('getAllLayersInATree get request', () => {
 		let serverResponse = {
 			json: () => [
 				{
@@ -76,7 +76,7 @@ describe('DataLayersService', () => {
 		};
 
 		spyOn(http, 'get').and.returnValue(Observable.of(new Response(serverResponse)));
-		dataLayersService.getAllLayersInATree('caseId');
-		expect(http.get).toHaveBeenCalledWith(`${dataLayersService.baseUrl}?caseId=caseId`);
+		dataLayersService.getAllLayersInATree();
+		expect(http.get).toHaveBeenCalledWith(`${dataLayersService.baseUrl}/layers?from=0&limit=100`);
 	});
 });

--- a/src/app/packages/menu-items/layers-manager/services/data-layers.service.ts
+++ b/src/app/packages/menu-items/layers-manager/services/data-layers.service.ts
@@ -38,7 +38,7 @@ export class DataLayersService {
 	}
 
 	public getAllLayersInATree(caseId?: string): Observable<LayerRootsBundle> {
-		const urlString: string = this.baseUrl + (caseId ? `?caseId=${caseId}` : '');
+		const urlString = `${this.baseUrl}/layers?from=0&limit=100`;
 		return this.http.get(urlString)
 			.map(this.extractData.bind(this))
 			.catch(err => {

--- a/src/app/packages/menu-items/layers-manager/services/data-layers.service.ts
+++ b/src/app/packages/menu-items/layers-manager/services/data-layers.service.ts
@@ -37,7 +37,7 @@ export class DataLayersService {
 		this.baseUrl = this.config.layersByCaseIdUrl;
 	}
 
-	public getAllLayersInATree(caseId?: string): Observable<LayerRootsBundle> {
+	public getAllLayersInATree(): Observable<LayerRootsBundle> {
 		const urlString = `${this.baseUrl}/layers?from=0&limit=100`;
 		return this.http.get(urlString)
 			.map(this.extractData.bind(this))

--- a/src/assets/config/app.config.json
+++ b/src/assets/config/app.config.json
@@ -1,7 +1,7 @@
 {
 	"production": false,
 	"casesConfig": {
-		"baseUrl": "http://localhost:9001/api/v1/cases",
+		"baseUrl": "http://localhost:8080/api/store",
 		"paginationLimit": 16,
 		"defaultCase": {
 			"id": "1234-5678",
@@ -100,7 +100,7 @@
 		"useHash": true
 	},
 	"layersManagerConfig": {
-		"layersByCaseIdUrl": "http://localhost:9001/api/v1/layers"
+		"layersByCaseIdUrl": "http://localhost:8080/api/store"
 	},
 	"overlaysConfig": {
 		"limit": 500


### PR DESCRIPTION
Addresses issue #1136 

Main changes:
* Update services to use the new API
* Fix a bug causing case duplications after removing a case, this occured due to overlapping between a `getPage` call with the wrong `from` parameter and a `delete` case request.