### PR TITLE
fix(source-type-notice): the tooltip is cut on small screen + center it

### DIFF
--- a/src/app/@ansyn/core/less/tooltip.less
+++ b/src/app/@ansyn/core/less/tooltip.less
@@ -35,7 +35,7 @@
 
 	&[tooltip-class*="bottom"] {
 		&:after {
-			aleft: auto;
+			left: auto;
 			top: auto;
 			bottom: 0;
 			transform: translteY(100%);
@@ -75,8 +75,16 @@
 		}
 	}
 
+	&[tooltip-class*="wrap"] {
+		&:after {
+			white-space: normal;
+			height: initial;
+			padding: 5px 10px;
+		}
+	}
+
 	&:after {
-		font-family: "Open Sans";
+		font-family: "Open Sans", sans-serif;
 		font-size: small;
 		opacity: 0;
 		position: absolute;

--- a/src/app/@ansyn/map-facade/components/overlay-source-type-notice/overlay-source-type-notice.component.html
+++ b/src/app/@ansyn/map-facade/components/overlay-source-type-notice/overlay-source-type-notice.component.html
@@ -1,3 +1,3 @@
 <div class="overlay-source-type-notice"
 	 [attr.tooltip-value]="title"
-	 tooltip-class="top right">{{title}}</div>
+	 tooltip-class="top wrap">{{title}}</div>


### PR DESCRIPTION
1 Adding "wrap" class def to tooltip.less (multi-line tooltip)
2 Using "wrap" class for the tooltip of the source-type-notice
3 Eliminating two warnings in tooltip.less