### PR TITLE
Fixing the hundrdth-ones animation

### DIFF
--- a/src/app/@ansyn/ansyn/assets/app-loader/app-loader.css
+++ b/src/app/@ansyn/ansyn/assets/app-loader/app-loader.css
@@ -1,3 +1,7 @@
+body {
+	overflow: hidden;
+}
+
 .wrapper {
 	display: flex;
 	justify-content: center;

--- a/src/app/@ansyn/ansyn/assets/app-loader/app-loader.css
+++ b/src/app/@ansyn/ansyn/assets/app-loader/app-loader.css
@@ -42,6 +42,7 @@
 
 .time-part.hundredths.ones .digit-wrapper {
 	animation-name: hundredths-ones;
+	animation-fill-mode: forwards;
 	animation-duration: 0.2s;
 	animation-iteration-count: 10
 }


### PR DESCRIPTION
The animation was missin the 'animation-fill-mode: forwards' attribute so the element did not retain the animation last frame.