### PR TITLE
change-ansyn-toast-location-to-statusBar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ansyn-src",
-  "version": "2.0.4",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/app/@ansyn/ansyn/ansyn/ansyn.component.html
+++ b/src/app/@ansyn/ansyn/ansyn/ansyn.component.html
@@ -27,6 +27,3 @@
 	<router-outlet></router-outlet>
 </ng-container>
 
-<!-- App overlays -->
-<ansyn-toast [duration]="4"></ansyn-toast>
-

--- a/src/app/@ansyn/ansyn/ansyn/ansyn.component.html
+++ b/src/app/@ansyn/ansyn/ansyn/ansyn.component.html
@@ -27,3 +27,6 @@
 	<router-outlet></router-outlet>
 </ng-container>
 
+<!-- App overlays -->
+<ansyn-toast [duration]="4"></ansyn-toast>
+

--- a/src/app/@ansyn/ansyn/modules/status-bar/components/status-bar/status-bar.component.html
+++ b/src/app/@ansyn/ansyn/modules/status-bar/components/status-bar/status-bar.component.html
@@ -4,6 +4,3 @@
 </div>
 <ansyn-display-panel></ansyn-display-panel>
 <ansyn-case-panel></ansyn-case-panel>
-
-<!-- App overlays -->
-<ansyn-toast [duration]="4"></ansyn-toast>

--- a/src/app/@ansyn/ansyn/modules/status-bar/components/status-bar/status-bar.component.html
+++ b/src/app/@ansyn/ansyn/modules/status-bar/components/status-bar/status-bar.component.html
@@ -4,3 +4,6 @@
 </div>
 <ansyn-display-panel></ansyn-display-panel>
 <ansyn-case-panel></ansyn-case-panel>
+
+<!-- App overlays -->
+<ansyn-toast [duration]="4"></ansyn-toast>

--- a/src/app/@ansyn/map-facade/components/toast/toast.component.less
+++ b/src/app/@ansyn/map-facade/components/toast/toast.component.less
@@ -15,6 +15,7 @@ div.toast {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+	z-index: 2;
 
 	span.message {
 		overflow: hidden;


### PR DESCRIPTION
When the time Line is hidden (isCollapse), the messages don't pop up either
![image](https://user-images.githubusercontent.com/46754845/84924008-a966e380-b0d0-11ea-9225-baaf9fd429a6.png)

after:
![image](https://user-images.githubusercontent.com/46754845/84924251-ee8b1580-b0d0-11ea-81b0-c37392251b5f.png)
